### PR TITLE
Make meson work with ffms2 master

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -55,6 +55,14 @@ foreach dep : [
                    required : false, static: b_static)
 
     optname = 'enable_@0@'.format(dep[0].split('-')[0])
+    if d.found() and dep[0] == 'ffms2'
+        dd = dependency('libavutil')
+        if dd.found()
+            deps += dd
+        else
+            d = dd  # makes following d.found() check fail
+        endif
+    endif
     if d.found() and get_option(optname) != 'false'
         deps += d
         conf.set('WITH_@0@'.format(dep[0].split('-')[0].to_upper()), '1')

--- a/src/video_provider_ffmpegsource.cpp
+++ b/src/video_provider_ffmpegsource.cpp
@@ -208,8 +208,10 @@ void FFmpegSourceVideoProvider::LoadVideo(agi::fs::path const& filename, std::st
 
 	// set thread count
 	int Threads = OPT_GET("Provider/Video/FFmpegSource/Decoding Threads")->GetInt();
-	if (FFMS_GetVersion() < ((2 << 24) | (17 << 16) | (2 << 8) | 1) && FFMS_GetSourceType(Index) == FFMS_SOURCE_LAVF)
+#if FFMS_VERSION < ((2 << 24) | (17 << 16) | (2 << 8) | 1)
+	if (FFMS_GetSourceType(Index) == FFMS_SOURCE_LAVF)
 		Threads = 1;
+#endif
 
 	// set seekmode
 	// TODO: give this its own option?


### PR DESCRIPTION
ffm2 removed a couple constants that are also defined by avutil and also some deprecated functions, out of which aegisub used one.